### PR TITLE
Add ncslt 1741 to master

### DIFF
--- a/DFC.Composite.HealthMonitor.Services/HealthMonitoring/HealthMonitoringProcessor.cs
+++ b/DFC.Composite.HealthMonitor.Services/HealthMonitoring/HealthMonitoringProcessor.cs
@@ -49,7 +49,7 @@ namespace DFC.Composite.HealthMonitor.Services.HealthMonitoring
         {
             foreach (var region in regions)
             {
-                var regionHealthEndpoint = new Uri(region.RegionEndpoint.Replace("{0}", $"{nameof(HealthMonitoringProcessor)}.{nameof(ProcessRegions)}.{Guid.NewGuid().ToString()}", StringComparison.OrdinalIgnoreCase));
+                var regionHealthEndpoint = new Uri(region.RegionEndpoint.Replace("{0}", $"{{}}", StringComparison.OrdinalIgnoreCase));
 
                 var isHealthy = await healthCheckerService.IsHealthy(regionHealthEndpoint, region.PageRegion == Data.Enums.PageRegion.Body, MediaTypeNames.Text.Html).ConfigureAwait(false);
                 if (isHealthy)
@@ -65,7 +65,7 @@ namespace DFC.Composite.HealthMonitor.Services.HealthMonitoring
         {
             foreach (var ajaxRequest in ajaxRequests)
             {
-                var ajaxRequestHealthEndpoint = new Uri(ajaxRequest.AjaxEndpoint.Replace("{0}", $"{nameof(HealthMonitoringProcessor)}.{nameof(ProcessAjaxRequests)}.{Guid.NewGuid().ToString()}", StringComparison.OrdinalIgnoreCase));
+                var ajaxRequestHealthEndpoint = new Uri(ajaxRequest.AjaxEndpoint.Replace("{0}", $"{{}}", StringComparison.OrdinalIgnoreCase));
 
                 var isHealthy = await healthCheckerService.IsHealthy(ajaxRequestHealthEndpoint, true, MediaTypeNames.Application.Json).ConfigureAwait(false);
                 if (isHealthy)

--- a/DFC.Composite.HealthMonitor.Services/HealthMonitoring/HealthMonitoringProcessor.cs
+++ b/DFC.Composite.HealthMonitor.Services/HealthMonitoring/HealthMonitoringProcessor.cs
@@ -49,7 +49,7 @@ namespace DFC.Composite.HealthMonitor.Services.HealthMonitoring
         {
             foreach (var region in regions)
             {
-                var regionHealthEndpoint = new Uri(region.RegionEndpoint.Replace("{0}", $"{{nameof(HealthMonitoringProcessor)}.{nameof(ProcessRegions)}.{Guid.NewGuid().ToString()}}", StringComparison.OrdinalIgnoreCase));
+                var regionHealthEndpoint = new Uri(region.RegionEndpoint.Replace("{0}", $"{nameof(HealthMonitoringProcessor)}.{nameof(ProcessRegions)}.{Guid.NewGuid().ToString()}", StringComparison.OrdinalIgnoreCase));
 
                 var isHealthy = await healthCheckerService.IsHealthy(regionHealthEndpoint, region.PageRegion == Data.Enums.PageRegion.Body, MediaTypeNames.Text.Html).ConfigureAwait(false);
                 if (isHealthy)

--- a/DFC.Composite.HealthMonitor.Services/HealthMonitoring/HealthMonitoringProcessor.cs
+++ b/DFC.Composite.HealthMonitor.Services/HealthMonitoring/HealthMonitoringProcessor.cs
@@ -49,7 +49,7 @@ namespace DFC.Composite.HealthMonitor.Services.HealthMonitoring
         {
             foreach (var region in regions)
             {
-                var regionHealthEndpoint = new Uri(region.RegionEndpoint.Replace("{0}", $"{{}}", StringComparison.OrdinalIgnoreCase));
+                var regionHealthEndpoint = new Uri(region.RegionEndpoint.Replace("{0}", $"{{nameof(HealthMonitoringProcessor)}.{nameof(ProcessRegions)}.{Guid.NewGuid().ToString()}}", StringComparison.OrdinalIgnoreCase));
 
                 var isHealthy = await healthCheckerService.IsHealthy(regionHealthEndpoint, region.PageRegion == Data.Enums.PageRegion.Body, MediaTypeNames.Text.Html).ConfigureAwait(false);
                 if (isHealthy)


### PR DESCRIPTION
Now health monitor will call findacourse search endpoint with valid payload for ajax requests and thus status code 200 will be returned for every call.
Because the status code will be OK (i.e. 200), it will update IsHealthy flag in appregistry cosmos table to true every time.